### PR TITLE
SDK初期化時のサンプルコード修正

### DIFF
--- a/app/src/main/java/ncmbdataquick/mbaas/com/nifty/datastorequickstart/MainActivity.java
+++ b/app/src/main/java/ncmbdataquick/mbaas/com/nifty/datastorequickstart/MainActivity.java
@@ -25,7 +25,7 @@ public class MainActivity extends AppCompatActivity {
         setSupportActionBar(toolbar);
         
         //**************** APIキーの設定とSDKの初期化 **********************
-        NCMB.initialize(this, "YOUR_APPLICATION_KEY", "YOUR_CLIENT_KEY");
+        NCMB.initialize(this.getApplicationContext(), "YOUR_APPLICATION_KEY", "YOUR_CLIENT_KEY");
     }
 
     @Override


### PR DESCRIPTION
下記のinitializeメソッド内のthisを
NCMB.initialize(this, "YOUR_APPLICATION_KEY", "YOUR_CLIENT_KEY");
⇒ NCMB.initialize(this.getApplicationContext(), "YOUR_APPLICATION_KEY", "YOUR_CLIENT_KEY");
に変更